### PR TITLE
Expose page and allow setting cookies

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,13 @@ class EpicGamesClientLoginAdapter {
     return this.browser.close();
   }
 
+  async getPage() {
+    return await this.browser.pages().then(pages => pages[0]);
+  }
+
   async getExchangeCode () {
     try {
-      const page = await this.browser.pages().then(pages => pages[0]);
+      const page = await this.getPage();
 
       const oldXsrfToken = (await page.cookies()).find((c) => c.name === 'XSRF-TOKEN').value;
       page.once('request', (req) => {
@@ -80,6 +84,7 @@ class EpicGamesClientLoginAdapter {
       inputDelay: 100,
       enterCredentialsTimeout: 60000,
       puppeteer: {},
+      cookies: [],
       ...userOptions,
     };
     const browser = await Puppeteer.launch({
@@ -95,6 +100,10 @@ class EpicGamesClientLoginAdapter {
       ...options.puppeteer,
     });
     const page = await browser.pages().then(pages => pages[0]);
+    if (options.cookies && options.cookies.length) {
+      await page.setCookie(...options.cookies);
+    }
+
     await page.goto('https://epicgames.com/id');
     const login = credentials.login || credentials.email || credentials.username;
     if (login && credentials.password) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 const Puppeteer = require('puppeteer');
+const { PendingXHR } = require('pending-xhr-puppeteer');
 const ExchangeCodeException = require('./exceptions/ExchangeCodeException');
 
 class EpicGamesClientLoginAdapter {
+
+  static get ACCOUNT_PAGE() {
+    return 'https://www.epicgames.com/account/personal';
+  }
 
   constructor (browser) {
     this.browser = browser;
@@ -19,35 +24,39 @@ class EpicGamesClientLoginAdapter {
     try {
       const page = await this.getPage();
 
-      const oldXsrfToken = (await page.cookies()).find((c) => c.name === 'XSRF-TOKEN').value;
-      page.once('request', (req) => {
-        req.continue({
-          method: 'GET',
-          headers: {
-            ...req.headers,
-            'X-XSRF-TOKEN': oldXsrfToken,
-          },
+      const oldXsrfToken = (await page.cookies()).find((c) => c.name === 'XSRF-TOKEN');
+      if (oldXsrfToken) {
+        page.once('request', (req) => {
+          req.continue({
+            method: 'GET',
+            headers: {
+              ...req.headers,
+              'X-XSRF-TOKEN': oldXsrfToken.value,
+            },
+          });
         });
-      });
-      await page.setRequestInterception(true);
+      }
+      await page.setRequestInterception(Boolean(oldXsrfToken));
       await page.goto('https://www.epicgames.com/id/api/authenticate');
       await page.setRequestInterception(false);
-      
-      page.once('request', (req) => {
-        req.continue({
-          method: 'GET',
-          headers: {
-            ...req.headers,
-            'X-XSRF-TOKEN': oldXsrfToken,
-          },
+
+      if (oldXsrfToken) {
+        page.once('request', (req) => {
+          req.continue({
+            method: 'GET',
+            headers: {
+              ...req.headers,
+              'X-XSRF-TOKEN': oldXsrfToken.value,
+            },
+          });
         });
-      });
-      await page.setRequestInterception(true);
+      }
+      await page.setRequestInterception(Boolean(oldXsrfToken));
         try {
           await page.goto('https://www.epicgames.com/id/api/csrf');
         } catch (e) {}
       await page.setRequestInterception(false);
-      
+
 
       const xsrfToken = (await page.cookies()).find((c) => c.name === 'XSRF-TOKEN').value;
       page.once('request', (req) => {
@@ -76,6 +85,24 @@ class EpicGamesClientLoginAdapter {
     }
   }
 
+  static async authenticate(credentials, page, options) {
+    const login = credentials.login || credentials.email || credentials.username;
+    if (login && credentials.password) {
+      const loginWithEpicButton = await page.waitForSelector('#login-with-epic');
+      await loginWithEpicButton.click();
+      const usernameOrEmailField = await page.waitForSelector('#email');
+      await usernameOrEmailField.type(login, { delay: options.inputDelay });
+      const passwordField = await page.waitForSelector('#password');
+      await passwordField.type(credentials.password, { delay: options.inputDelay });
+      const loginButton = await page.waitForSelector('#login:not(:disabled)');
+      await loginButton.click();
+    }
+
+    await page.waitForResponse(this.ACCOUNT_PAGE, {
+      timeout: options.enterCredentialsTimeout,
+    });
+  }
+
   static async init (credentials={}, userOptions={}) {
     const options = {
       language: 'en-US',
@@ -99,26 +126,25 @@ class EpicGamesClientLoginAdapter {
       ],
       ...options.puppeteer,
     });
+
     const page = await browser.pages().then(pages => pages[0]);
     if (options.cookies && options.cookies.length) {
       await page.setCookie(...options.cookies);
     }
 
+    const pendingXHR = new PendingXHR(page);
+    const pendingDocument = new PendingXHR(page);
+    pendingDocument.resourceType = 'document';
     await page.goto('https://epicgames.com/id');
-    const login = credentials.login || credentials.email || credentials.username;
-    if (login && credentials.password) {
-      const loginWithEpicButton = await page.waitForSelector('#login-with-epic');
-      await loginWithEpicButton.click();
-      const usernameOrEmailField = await page.waitForSelector('#email');
-      await usernameOrEmailField.type(login, { delay: options.inputDelay });
-      const passwordField = await page.waitForSelector('#password');
-      await passwordField.type(credentials.password, { delay: options.inputDelay });
-      const loginButton = await page.waitForSelector('#login:not(:disabled)');
-      await loginButton.click();
+    await page.waitFor(1000);
+    await pendingXHR.waitOnceForAllXhrFinished();
+    await page.waitFor(1000);
+    await pendingDocument.waitOnceForAllXhrFinished();
+
+    if (page.url() != this.ACCOUNT_PAGE) {
+      await this.authenticate(credentials, page, options);
     }
-    await page.waitForResponse((response) => response.url() === 'https://www.epicgames.com/account/personal', {
-      timeout: options.enterCredentialsTimeout,
-    });
+
     return new this(browser);
   }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 		"epicgames",
 		"epicgames-client",
 		"login",
-    "exchange",
-    "captcha"
+		"exchange",
+		"captcha"
 	],
 	"homepage": "https://github.com/SzymonLisowiec/node-epicgames-client-login-adapter",
 	"bugs": {
@@ -24,6 +24,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-    "puppeteer": "^2.1.1"
-  }
+		"pending-xhr-puppeteer": "^2.3.2",
+		"puppeteer": "^2.1.1"
+	}
 }


### PR DESCRIPTION
Expose `page` in API so that clients (eg. `epicgames-freebies-claimer`) can reuse cookies we collected.

Also add option so clients can provide cookies.
Basically currently each time you try to login you'll get fresh session without any cookies
which will make that you will be always asked to solve CAPTCHA.
If we reuse cookies then we won't need to solve CAPTCHA's all the time.

